### PR TITLE
fix: Enable DNS resolution in deactivateExitNode command

### DIFF
--- a/tailscale.go
+++ b/tailscale.go
@@ -75,7 +75,7 @@ func deactivateExitNode() {
 	cmd := exec.Command(tailscalePath,
 		"up",
 		"--exit-node=",
-		"--accept-dns=false",
+		"--accept-dns=true",
 		"--shields-up")
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
The deactivateExitNode command now allows DNS resolution by setting the `--accept-dns` flag to true.